### PR TITLE
eosws: review-round fixes (cursor overlap P0, watchdog P2, shutdown P2)

### DIFF
--- a/eosws/recenttxhub.go
+++ b/eosws/recenttxhub.go
@@ -4,6 +4,7 @@ package eosws
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -117,6 +118,12 @@ func (h *RecentTxHub) Launch(ctx context.Context) {
 	libRef := bstream.NewBlockRefFromID(h.initialLIB)
 
 	handler := bstream.HandlerFunc(func(block *bstream.Block, obj interface{}) error {
+		// Stamp the watchdog NOW (block received) rather than after the
+		// switch so a slow onStepNew on a heavy block doesn't trigger a
+		// false stall flip (R1 #4). Watchdog measures stream silence, not
+		// per-block processing time.
+		h.lastBlockNano.Store(time.Now().UnixNano())
+
 		fObj := obj.(*forkable.ForkableObject)
 		blk := block.ToNative().(*pbcodec.Block)
 
@@ -128,7 +135,6 @@ func (h *RecentTxHub) Launch(ctx context.Context) {
 		case forkable.StepUndo:
 			h.onStepUndo(blk.Id)
 		}
-		h.lastBlockNano.Store(time.Now().UnixNano())
 		h.ready.Store(true)
 		return nil
 	})
@@ -149,6 +155,13 @@ func (h *RecentTxHub) Launch(ctx context.Context) {
 		h.ready.Store(false)
 	})
 
+	// Clean-shutdown: propagate ctx cancel to the bstream source so it
+	// drops its relayer connection and exits its goroutines within the
+	// pod's terminationGracePeriodSeconds window (R4 #4).
+	go func() {
+		<-ctx.Done()
+		eternalSource.Shutdown(nil)
+	}()
 	go h.runWatchdog(ctx)
 	eternalSource.Run()
 }
@@ -392,7 +405,7 @@ func (h *RecentTxHub) Snapshot(limit int) (*mdl.TransactionList, bool) {
 	}
 
 	out := &mdl.TransactionList{Transactions: make([]*v1.TransactionLifecycle, 0, limit)}
-	var lastBlockID string
+	var lastBlockNum uint32
 	for i := 0; i < h.count && len(out.Transactions) < limit; i++ {
 		idx := (h.head - 1 - i + h.size) % h.size
 		entry := h.ring[idx]
@@ -404,7 +417,7 @@ func (h *RecentTxHub) Snapshot(limit int) (*mdl.TransactionList, bool) {
 		// the JSON encoder which runs after we release the lock.
 		cp := *entry.lc
 		out.Transactions = append(out.Transactions, &cp)
-		lastBlockID = entry.blockID
+		lastBlockNum = entry.blockNum
 	}
 
 	if len(out.Transactions) < limit {
@@ -413,14 +426,39 @@ func (h *RecentTxHub) Snapshot(limit int) (*mdl.TransactionList, bool) {
 		return nil, false
 	}
 
-	// Build the next-page cursor. Use (lastBlockID, 0xffff) so a
-	// subsequent ?cursor=… request resumes one block earlier in the
-	// Bigtable path (matches db.go:331 encoding scheme).
-	out.Cursor = opaqueCursor(lastBlockID + ":" + hexUint16(0xffff))
+	// Build the next-page cursor pointing one block earlier than the ring's
+	// oldest returned tx. We synthesize a 32-byte block-id whose first 4
+	// bytes encode (lastBlockNum - 1) — db.ListMostRecentTransactions only
+	// uses eos.BlockNum(blockID) to start the scan and never matches the
+	// synthesized id against any real blk.Id, so the in-block skip predicate
+	// (`blk.Id == startBlockID && trxIndex > startTrxIndex`) never fires
+	// and the Bigtable fall-through resumes cleanly at lastBlockNum-1,
+	// returning all txs from there backward without overlap.
+	//
+	// Trade-off: any txs that lived in the ring's last block but weren't
+	// returned in this page (because limit landed mid-block) are NOT
+	// surfaced on the next page. With Ultra's home-page limit=25 vs the
+	// chain's typical 1-3 tx/block this case is rare; when it happens the
+	// missing txs remain discoverable via /v0/transactions/{id} or the
+	// search endpoints.
+	out.Cursor = opaqueCursor(syntheticPrevBlockID(lastBlockNum) + ":" + hexUint16(0xffff))
 
 	recentTxRingHits.Inc()
 	return out, true
 }
+
+// syntheticPrevBlockID returns a 64-hex-char string whose first 8 chars
+// encode (blockNum - 1). The remaining 56 chars are zeros — they are never
+// matched against a real blk.Id by the Bigtable fall-through, so collisions
+// are not a concern.
+func syntheticPrevBlockID(blockNum uint32) string {
+	if blockNum == 0 {
+		return "00000000" + zero56
+	}
+	return fmt.Sprintf("%08x", blockNum-1) + zero56
+}
+
+const zero56 = "00000000000000000000000000000000000000000000000000000000"
 
 // alwaysCanonical is the inCanonicalChain discriminator passed to
 // MergeTransactionEvents. The forkable handler only fires StepNew/StepRedo

--- a/eosws/recenttxhub_test.go
+++ b/eosws/recenttxhub_test.go
@@ -5,12 +5,14 @@ package eosws
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	v1 "github.com/dfuse-io/eosws-go/mdl/v1"
 	eos "github.com/eoscanada/eos-go"
+	"github.com/streamingfast/opaque"
 	atom "go.uber.org/atomic"
 )
 
@@ -233,15 +235,60 @@ func TestRecentTxHub_TombstoneSaturationFallsThrough(t *testing.T) {
 	}
 }
 
-// --- 9. Cursor encoding is opaque + non-empty ------------------------------
+// --- 9. Cursor encodes (lastBlockNum-1, 0xffff) so Bigtable fall-through
+//        resumes WITHOUT re-fetching the ring's last block (R3 P0 fix).
 
-func TestRecentTxHub_SnapshotCursorEncoded(t *testing.T) {
+func TestRecentTxHub_SnapshotCursorPointsOneBlockEarlier(t *testing.T) {
 	h := newTestHub(10)
-	h.testAppend("0000000064abc...blk", 100, mkLC("t1", false), mkLC("t2", false))
+	h.testAppend("blkA", 100, mkLC("t1", false), mkLC("t2", false))
 
-	got, _ := h.Snapshot(2)
-	if got.Cursor == "" {
-		t.Errorf("expected non-empty opaque cursor")
+	got, ok := h.Snapshot(2)
+	if !ok || got.Cursor == "" {
+		t.Fatalf("expected non-empty cursor; ok=%v cursor=%q", ok, got.Cursor)
+	}
+	// Round-trip the opaque cursor and confirm the embedded blockNum is
+	// lastBlockNum-1 (so the Bigtable fall-through skips the ring's last
+	// block instead of re-fetching it).
+	raw, err := opaque.FromOpaque(got.Cursor)
+	if err != nil {
+		t.Fatalf("FromOpaque: %v", err)
+	}
+	parts := strings.Split(raw, ":")
+	if len(parts) != 2 {
+		t.Fatalf("cursor format %q does not split into 2 parts on ':'", raw)
+	}
+	if len(parts[0]) < 8 {
+		t.Fatalf("cursor blockID part too short: %q", parts[0])
+	}
+	blockNum := eos.BlockNum(parts[0])
+	if blockNum != 99 { // lastBlockNum (100) - 1
+		t.Errorf("cursor blockNum = %d, want %d", blockNum, 99)
+	}
+	if parts[1] != "ffff" {
+		t.Errorf("cursor trxIndex = %q, want %q", parts[1], "ffff")
+	}
+}
+
+// --- 9b. syntheticPrevBlockID never produces a real-block collision ---------
+
+func TestSyntheticPrevBlockID(t *testing.T) {
+	cases := []struct {
+		in   uint32
+		want uint32 // expected blockNum after eos.BlockNum round-trip
+	}{
+		{1, 0},
+		{100, 99},
+		{313_774_854, 313_774_853},
+		{0, 0}, // floor at 0 to avoid underflow
+	}
+	for _, c := range cases {
+		got := syntheticPrevBlockID(c.in)
+		if len(got) != 64 {
+			t.Errorf("syntheticPrevBlockID(%d) length = %d, want 64", c.in, len(got))
+		}
+		if n := eos.BlockNum(got); n != c.want {
+			t.Errorf("eos.BlockNum(syntheticPrevBlockID(%d)) = %d, want %d", c.in, n, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes from the §14 post-implementation review round on the recent-tx ring buffer (PR #57, shipped as v3.2.0-2.0.1). Three findings:

| Finding | Severity | Source |
|---|---|---|
| Cursor encoding caused pagination overlap | **P0** | R3 |
| Watchdog false-positive on slow onStepNew | P2 | R1 |
| EternalSource not Shutdown on ctx.Done | P2 | R4 |

Full review-round doc: ultraOS-doc/dfuse-deep-dive/12-EOSWS_RING_BUFFER_REVIEW_ROUND.md (in progress).

### R3 P0 — Cursor overlap

Previous code emitted cursor `(lastBlockID, 0xffff)`. Bigtable's `ListMostRecentTransactions` skip predicate at `db.go:283` is `blk.Id == startBlockID && trxIndex > int(startTrxIndex)`. With `startTrxIndex = 65535`, no uint16 trxIndex can satisfy `> 65535` — so EVERY tx in `lastBlockID` was re-fetched on the next-page request, producing duplicate rows in the eosq home page's pagination.

Fix: synthesize a 32-byte block-id whose first 4 bytes encode `lastBlockNum - 1`. `eos.BlockNum(blockID)` only reads those 4 bytes for the scan-start, and the synthesized id never matches any real `blk.Id` so the in-block skip predicate stays inert. Bigtable resumes cleanly at `lastBlockNum - 1` with no overlap.

Trade-off documented in the Snapshot godoc: any txs in the ring's last block that weren't returned in this page (limit landed mid-block) are not surfaced on the next page. On Ultra at limit=25 vs 1–3 tx/block this is rare; missing txs remain discoverable via `/v0/transactions/{id}` or search.

Two new tests assert the fix: `TestRecentTxHub_SnapshotCursorPointsOneBlockEarlier` + `TestSyntheticPrevBlockID`.

### R1 P2 — Watchdog false-positive

`lastBlockNano.Store` was at the BOTTOM of the handler (after `onStepNew`'s per-trx synthesis). A heavy block + GC pause could push processing time past the 2s watchdog window even though the stream was healthy. Moved the stamp to the TOP so the watchdog measures stream silence, not processing time.

### R4 P2 — Clean-shutdown leak

`eternalSource.Run()` never received a Shutdown signal on `ctx.Done()`. Process termination eventually reaped within `terminationGracePeriodSeconds=60` so no long-lived leak, but it violated the launcher pattern other apps use. Added a small goroutine that calls `eternalSource.Shutdown(nil)` on ctx cancel.

## Test plan

- [x] `go test -race ./eosws/...` PASS
- [x] `gofmt -s -l .` clean
- [ ] Image tag `v3.2.0-2.0.2` built + ultra-apps testnet bumped + verify on testnet
- [ ] Soak continuation; mainnet rollout after user authorization

## Pairs with

- Chart kill-switch fix (P1 from R4): separate PR on the `dfuse` chart repo — `default 500` was masking `recentTxRingSize=0`, fixed via `hasKey`.