### PR TITLE
fix(codec): reset ABI decoder on mid-block fork to prevent mindreader deadlock

### DIFF
--- a/codec/abi_decoder.go
+++ b/codec/abi_decoder.go
@@ -168,6 +168,35 @@ func (c *ABIDecoder) endBlock(block *pbcodec.Block) error {
 	return nil
 }
 
+// abortBlock discards the block currently being decoded. It is called when a fork
+// (SWITCH_FORK) interrupts a block before its ACCEPTED_BLOCK is emitted. Without it,
+// the decoder stays "armed" on the aborted block and the next startBlock fails with
+// "start block ... while already processing block #N", which terminates the
+// ConsoleReader and wedges the mindreader.
+//
+// Any decoding jobs already queued for the active block are drained (so the ordered
+// pool returns to a clean state and stale jobs never execute against a later block's
+// activeBlockNum), then the active block is cleared so the next startBlock proceeds.
+//
+// lastSeenBlockRef is intentionally left untouched: the aborted block was never
+// completed, so fork detection on the next startBlock must compare against the last
+// *successfully* processed block. The ABI cache is also left as-is; any ABIs the
+// aborted block committed are removed by the truncate-on-next-global-sequence logic
+// when the replacement chain's first transaction arrives (same as a between-block fork).
+func (c *ABIDecoder) abortBlock() error {
+	if c.activeBlockNum == noActiveBlockNum {
+		return nil
+	}
+
+	if err := c.drain(); err != nil {
+		return fmt.Errorf("unable to drain decoding queue on block abort: %w", err)
+	}
+
+	c.activeBlockNum = noActiveBlockNum
+
+	return nil
+}
+
 func (c *ABIDecoder) processTransaction(trxTrace *pbcodec.TransactionTrace) error {
 	zlog.Debug("processing transaction for decoding", zap.String("trx_id", trxTrace.Id))
 

--- a/codec/abi_decoder_test.go
+++ b/codec/abi_decoder_test.go
@@ -669,3 +669,43 @@ func maybePrintBlock(t *testing.T, block *pbcodec.Block) {
 
 	zlog.Debug("processing test block", zap.Any("block", normalizedOut))
 }
+
+func Test_ABIDecoder_abortBlock(t *testing.T) {
+	t.Run("no active block is a no-op", func(t *testing.T) {
+		decoder := newABIDecoder()
+
+		require.NoError(t, decoder.abortBlock())
+
+		// The decoder must remain usable after a no-op abort.
+		require.NoError(t, decoder.startBlock(1))
+	})
+
+	t.Run("drains queued jobs then a fresh block decodes cleanly", func(t *testing.T) {
+		testABI := readABI(t, "test.1.abi.json")
+		decoder := newABIDecoder()
+
+		// Block 10 starts and queues decoding work, then a fork aborts it before endBlock.
+		aborted := testBlock(t, "0000000aaa", "00000009aa",
+			trxTrace(t, actionTrace(t, "test:test:act1", 0, 1, testABI, `{"from":"test1"}`)),
+		)
+		require.NoError(t, decoder.startBlock(aborted.Num()))
+		for _, trxTrace := range aborted.UnfilteredTransactionTraces {
+			require.NoError(t, decoder.processTransaction(trxTrace))
+		}
+
+		require.NoError(t, decoder.abortBlock())
+
+		// The replacement block must start and fully decode without error or deadlock.
+		// Before the fix, the leftover activeBlockNum would fail startBlock, and any
+		// undrained block-10 jobs would execute against block 11's activeBlockNum and
+		// poison the ordered pool, hanging endBlock forever.
+		replacement := testBlock(t, "0000000baa", "00000009aa",
+			trxTrace(t, actionTrace(t, "test:test:act1", 0, 2, testABI, `{"from":"test2"}`)),
+		)
+		require.NoError(t, decoder.startBlock(replacement.Num()))
+		for _, trxTrace := range replacement.UnfilteredTransactionTraces {
+			require.NoError(t, decoder.processTransaction(trxTrace))
+		}
+		require.NoError(t, decoder.endBlock(replacement))
+	})
+}

--- a/codec/consolereader.go
+++ b/codec/consolereader.go
@@ -245,6 +245,13 @@ func (l *ConsoleReader) Read() (out interface{}, err error) {
 
 		case strings.HasPrefix(line, "SWITCH_FORK"):
 			zlog.Info("fork signal, restarting state accumulation from beginning")
+			// A fork can interrupt a block mid-emission (before ACCEPTED_BLOCK). The ABI
+			// decoder accumulates per-block state and in-flight decoding jobs; abort them
+			// here so the next START_BLOCK starts cleanly instead of erroring with
+			// "already processing block" and wedging the mindreader.
+			if err = ctx.abiDecoder.abortBlock(); err != nil {
+				return nil, l.formatError(line, err)
+			}
 			ctx.resetBlock()
 
 		case strings.HasPrefix(line, "ABIDUMP START"):

--- a/codec/consolereader_test.go
+++ b/codec/consolereader_test.go
@@ -871,3 +871,28 @@ func newParseCtx() *parseCtx {
 		trx:        &pbcodec.TransactionTrace{},
 	}
 }
+
+// TestConsoleReader_ForkMidBlock_DoesNotWedge reproduces the recurring mindreader
+// deadlock (see devops-docs/dfuse/MINDREADER_DEADLOCK_DURABLE_FIX_2026-05-05.md).
+//
+// A fork (SWITCH_FORK) interrupts block 10 before its ACCEPTED_BLOCK, then nodeos
+// re-emits the replacement block. Before the fix, the ABI decoder's active-block
+// state was never reset on SWITCH_FORK (the SWITCH_FORK case only reset the
+// ConsoleReader's block accumulator, not the decoder), so the next START_BLOCK
+// returned "start block for block #11 received while already processing block #10",
+// which terminated the ConsoleReader and wedged the mindreader.
+func TestConsoleReader_ForkMidBlock_DoesNotWedge(t *testing.T) {
+	dmlog := "DMLOG START_BLOCK 10\n" +
+		"DMLOG SWITCH_FORK\n" +
+		"DMLOG START_BLOCK 11\n"
+
+	cr := testReaderConsoleReader(t, bytes.NewBufferString(dmlog), func() {})
+
+	for {
+		_, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## Problem

The recurring **mindreader ~3-day deadlock** (`devops-docs/dfuse/MINDREADER_DEADLOCK_DURABLE_FIX_2026-05-05.md`) has a real root cause in the deep-mind parser, not just the kubelet-probe band-aid shipped earlier.

A `SWITCH_FORK` can interrupt a block **before** its `ACCEPTED_BLOCK` is emitted (routine on Savanna). The `SWITCH_FORK` handler called `ctx.resetBlock()`, which reset the `ConsoleReader`'s block accumulator **but never reset the ABI decoder**. So `ABIDecoder.activeBlockNum` stayed armed on the aborted block, and the next `START_BLOCK` failed in `startBlock()`:

```
start block for block #N+1 received while already processing block #N
```

That error terminates the `ConsoleReader`, which drops `dfuseeos` into the `WaitForTermination` loop (PID 1 alive, `nodeos` gone) — the exact wedge signature in the incident doc. The kubelet liveness probe only restarts the container ~180s later (with a data gap each time); it does not address this code path.

## Fix

Add `ABIDecoder.abortBlock()` and call it from the `SWITCH_FORK` handler. It:
- **drains** any decoding jobs already queued for the aborted block (reusing `endBlock`'s proven `drain()`), so stale jobs never execute against a later block's `activeBlockNum` and poison the ordered pool (a worse deadlock variant), then
- clears `activeBlockNum` so the next `START_BLOCK` starts clean.

`lastSeenBlockRef` and the ABI cache are intentionally **left untouched**: the aborted block was never completed, and the existing truncate-on-next-global-sequence logic removes any ABIs it committed — exactly as already happens for a fork that lands *between* blocks (that path already worked; only the mid-block path was broken).

Minimal/surgical: +101 lines, no signature changes, no behavior change on the non-fork path.

## Tests
- `TestConsoleReader_ForkMidBlock_DoesNotWedge` — integration reproduction through the real `ConsoleReader.Read()` API; **fails on the exact incident error before the fix**, passes after.
- `Test_ABIDecoder_abortBlock` — unit coverage: no-op when no active block; drain-then-clean-block (proves queued jobs are drained, not left to poison the pool).
- Full `codec/...` suite green under `-race`; `go vet` clean; `node-manager` builds clean.

## Rollout caveat
This touches the **critical ingest parser** (deep-mind → blocks), and `ultra-prod-testnet` was torn down (2026-06-18), so the usual soak environment is gone. Recommend staging on a `kubectl delete pod`-recreated single mindreader replica / low-traffic window and watching for a clean fork before fleet rollout. Ships via the normal `dfuse-eosio` image bump (`global.image.dfuseTag`); the kubelet probe stays as a backstop.