### PR TITLE
fix(abicodec): RLock ABI cache reads to fix concurrent map read/write crash

### DIFF
--- a/abicodec/cache.go
+++ b/abicodec/cache.go
@@ -44,7 +44,7 @@ type Cache interface {
 type DefaultCache struct {
 	Abis      map[string][]*ABICacheItem // from account to the ABIs in range
 	Cursor    string                     `json:"cursor"`
-	lock      sync.Mutex
+	lock      sync.RWMutex
 	store     dstore.Store
 	cacheName string
 	dirty     bool
@@ -196,6 +196,15 @@ func (c *DefaultCache) SaveState() error {
 }
 
 func (c *DefaultCache) ABIAtBlockNum(account string, blockNum uint32) *ABICacheItem {
+	// Read-lock the cache: this is the decode hot path and runs concurrently with
+	// setabi writes (SetABIAtBlockNum/RemoveABIAtBlockNum) that mutate the Abis map
+	// and reslice the per-account slice under the write lock. Without this, the
+	// concurrent map read/write panics the (single-replica) abicodec process.
+	// The returned *ABICacheItem is safe to use after RUnlock: items are immutable
+	// once created (writers replace slots or rearrange the slice, never mutate items).
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	if abis, ok := c.Abis[account]; ok {
 
 		for i := len(abis) - 1; i >= 0; i-- {

--- a/abicodec/cache_race_test.go
+++ b/abicodec/cache_race_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package abicodec
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestDefaultCache_ConcurrentReadWrite reproduces the abicodec ABI-cache data race.
+//
+// The decode hot path (decodeAction/decodeTable/getABI -> Cache.ABIAtBlockNum) read
+// the Abis map and iterated the per-account slice with NO lock, while setabi
+// processing writes the same map/slice (SetABIAtBlockNum) under c.lock. On the
+// single-replica abicodec pod this surfaces as a fatal "concurrent map read and map
+// write" runtime crash. Must be run under `-race`.
+func TestDefaultCache_ConcurrentReadWrite(t *testing.T) {
+	cache := &DefaultCache{Abis: make(map[string][]*ABICacheItem)}
+	abi := NewTestABI("v1")
+
+	const account = "eosio.token"
+	cache.SetABIAtBlockNum(account, 1, abi)
+
+	const iterations = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: append/replace ABI versions (mutates the map and reslices the slice).
+	go func() {
+		defer wg.Done()
+		for i := uint32(2); i < iterations; i++ {
+			cache.SetABIAtBlockNum(account, i, abi)
+		}
+	}()
+
+	// Reader: the lock-free path used by every decode/getABI RPC.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = cache.ABIAtBlockNum(account, ^uint32(0))
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem (stability sweep D7 — see `ultraOS-doc/dfuse-deep-dive/17`)

`DefaultCache.ABIAtBlockNum` — the decode hot path used by every `decodeAction` / `decodeTable` / `getABI` RPC (`abicodec/decoder.go:39,53,68`) — read the `Abis` map and iterated the per-account slice with **no lock**, while setabi processing writes the same map/slice (`SetABIAtBlockNum`/`RemoveABIAtBlockNum`) under `c.lock`.

On the **single-replica** abicodec pod, any concurrent decode + setabi is a fatal, unrecoverable **`concurrent map read and map write`** runtime crash → cold-cache replay on restart. The in-place reslice (`cache.go:132`) also tears the slice a reader is walking.

## Fix

Convert `c.lock` from `sync.Mutex` to `sync.RWMutex` and take a **read lock** in `ABIAtBlockNum`. Writers are unchanged (`.Lock()` works on `RWMutex`). The returned `*ABICacheItem` is safe to use after `RUnlock` because items are **immutable** once created — writers replace slice slots or rearrange the slice, never mutate an existing item's fields. Minimal/surgical: 1-line type change + RLock on one method.

## Test
- `TestDefaultCache_ConcurrentReadWrite` runs concurrent `SetABIAtBlockNum` (writer) + `ABIAtBlockNum` (reader). **Fails under `-race` before the fix** (race detector: write `cache.go:134` vs read `cache.go:199`); green after.
- Full `abicodec/...` suite green under `-race`; `go vet` clean.

## Scope note
Surgical fix for the fatal map race only. Related abicodec findings in doc 17 are **not** in this PR: D6 (cache never evicts → 1Gi OOM loop), D9 (`SaveState`/`Export` hold the lock during GCS I/O), D8 (`DecodeAction` wrongly calls `decodeTable`). Ships via the normal `dfuse-eosio` image bump alongside #61.