### PR TITLE
fix(deps): adopt ultraio/fluxdb fork — write lock in updateSpeculativeWrites (R2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -241,3 +241,5 @@ replace github.com/eoscanada/eos-go => github.com/ultraio/eos-go v0.9.1-0.202401
 replace github.com/streamingfast/bstream => github.com/ultraio/bstream v0.0.0-20260528112257-31c9b7ce2d8c
 
 replace github.com/streamingfast/kvdb => github.com/ultraio/kvdb v0.0.2-0.20260622235929-e3abc7aa9a5c
+
+replace github.com/streamingfast/fluxdb => github.com/ultraio/fluxdb v0.0.0-20260623000039-dc09c1e130f2

--- a/go.sum
+++ b/go.sum
@@ -873,8 +873,6 @@ github.com/streamingfast/dmetrics v0.0.0-20210811180524-8494aeb34447 h1:oZwOVjxp
 github.com/streamingfast/dmetrics v0.0.0-20210811180524-8494aeb34447/go.mod h1:VLdQY/FwczmC/flqWkcsBbqXO4BhU4zQDSK7GMrpcjY=
 github.com/streamingfast/dtracing v0.0.0-20210811175635-d55665d3622a h1:/7Rw3pYpueJYOQReTJpfAhAPk0uZD4I58LfiUAr4IMc=
 github.com/streamingfast/dtracing v0.0.0-20210811175635-d55665d3622a/go.mod h1:bqiYZaX6L/MoXNfFQeAdau6g9HLA3yKHkX8KzStt58Q=
-github.com/streamingfast/fluxdb v0.0.0-20210811195408-0515ef659298 h1:r19r7hvD1+Iou/eGEf50ZvNMRTIc6yHTP2fkhAIl/gk=
-github.com/streamingfast/fluxdb v0.0.0-20210811195408-0515ef659298/go.mod h1:4nAMvYjDQN0tfnnfBdnSoMCTivXDM4xPdZpROFF7U64=
 github.com/streamingfast/graphql-go v0.0.0-20210204202750-0e485a040a3c h1:myR0e7b9irsMsRHs42+Oo6ZVuHfGTDHjQhlI1Tk/9/U=
 github.com/streamingfast/graphql-go v0.0.0-20210204202750-0e485a040a3c/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/streamingfast/jsonpb v0.0.0-20210811021341-3670f0aa02d0 h1:g8eEYbFSykyzIyuxNMmHEUGGUvJE0ivmqZagLDK42gw=
@@ -965,6 +963,8 @@ github.com/ultraio/eos-go v0.9.1-0.20240122103729-ce0cb43bd3d0 h1:otkRhv36YWODmq
 github.com/ultraio/eos-go v0.9.1-0.20240122103729-ce0cb43bd3d0/go.mod h1:BCTBH+XkEi+gO38MHRDm0LLcUhaIlekey+SCBaIAJTk=
 github.com/ultraio/firehose v0.0.0-20240521103135-c3c1a0202f8d h1:fz4bjdjVe1EKvsd66N1YpJAdDG58gkCseSPhE2kG1Ow=
 github.com/ultraio/firehose v0.0.0-20240521103135-c3c1a0202f8d/go.mod h1:fdjssmWmCcWRAEnlfIeUkqn6e4FCETdXn7U8c/hBiyw=
+github.com/ultraio/fluxdb v0.0.0-20260623000039-dc09c1e130f2 h1:A0+WfM+ajxgw3HdbZjF5+Ji7zluYjtWRtFgyZMvi+JY=
+github.com/ultraio/fluxdb v0.0.0-20260623000039-dc09c1e130f2/go.mod h1:4nAMvYjDQN0tfnnfBdnSoMCTivXDM4xPdZpROFF7U64=
 github.com/ultraio/kvdb v0.0.2-0.20260622235929-e3abc7aa9a5c h1:ZeZYIfDdbpUUw/Sd2iPJR2lMg/KhPCX5Q9BdIXBcEjU=
 github.com/ultraio/kvdb v0.0.2-0.20260622235929-e3abc7aa9a5c/go.mod h1:4dQjd/1ZHhyfAWaFN8cwtdPGZU5LLmAQ7zK2HE5Ok40=
 github.com/unrolled/render v1.0.0 h1:XYtvhA3UkpB7PqkvhUFYmpKD55OudoIeygcfus4vcd4=


### PR DESCRIPTION
## Problem (stability sweep R2 — `ultraOS-doc/dfuse-deep-dive/17`)

`fluxdb` `FluxDBHandler.updateSpeculativeWrites` (`pipeline.go:234-251`) **mutates** `p.speculativeWrites` and `p.headBlock` while holding only `speculativeReadsLock.RLock()`. The concurrent readers `HeadBlock` and `FetchSpeculativeWrites` also hold `RLock`, so there is **no writer exclusion** → data race + torn head-vs-writes during reorgs. (statedb is the consumer.)

## Upstream check (per the fork-drift discipline)
- **Fixed upstream** in `25bfcf9` (2022-06) — uses full `Lock()`.
- But **not drop-in**: the fix is bundled with a refactor that changes `FetchSpeculativeWrites`' signature (**statedb calls it**), switches `ProcessBlock` to proto blocks, and rebuilds on `hub.ForkableHub`. A version bump **breaks statedb**.
- No existing `EOS-Nation/fluxdb` / `ultraio/fluxdb`.

→ Thin fork **`ultraio/fluxdb`** pinned to the **same upstream commit `0515ef6`** + only the 2-line lock change.

## Change
`replace github.com/streamingfast/fluxdb => github.com/ultraio/fluxdb v0.0.0-20260623000039-dc09c1e130f2`
([ultraio/fluxdb@fix/speculative-writes-lock](https://github.com/ultraio/fluxdb/tree/fix/speculative-writes-lock)). `RLock`→`Lock` in `updateSpeculativeWrites`.

**Deadlock-safe** (verified): `updateSpeculativeWrites` has a single caller (`ProcessBlock` StepNew) which holds no lock; the readers are leaf and never call it.

## Verification
- `go mod tidy` clean; `go build ./statedb/...` clean.
- `go test ./statedb/... -race` green.

Ships via the normal `dfuse-eosio` image bump alongside #61/#62/#63.