### PR TITLE
feat(eosws): cap reversible buffer on the 3 long-lived hubs (B1 completeness)

### DIFF
--- a/eosws/completion/pipeline.go
+++ b/eosws/completion/pipeline.go
@@ -64,7 +64,10 @@ func (p *Pipeline) Launch() {
 
 	irrRef := bstream.NewBlockRefFromID(libID)
 	gateHandler := bstream.NewBlockNumGate(uint64(startBlock), bstream.GateExclusive, handler, bstream.GateOptionWithLogger(zlog))
-	forkableHandler := forkable.New(gateHandler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(irrRef))
+	// Bound the reversible buffer: this pipeline is long-lived (per-pod) and runs on
+	// real chain LIB, so a LIB stall would grow it unbounded -> OOM. Fail fast instead
+	// (clean restart) — see ultraOS-doc dfuse-deep-dive/17 (B1). Tune per pod memory.
+	forkableHandler := forkable.New(gateHandler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(irrRef), forkable.WithMaxReversibleBlocks(10_000))
 	source := p.subscriptionHub.NewSourceFromBlockRef(irrRef, forkableHandler)
 
 	source.Run()

--- a/eosws/headinfo.go
+++ b/eosws/headinfo.go
@@ -96,7 +96,10 @@ func (h *HeadInfoHub) Launch(ctx context.Context) {
 	})
 
 	gateHandler := bstream.NewBlockNumGate(uint64(startBlock), bstream.GateExclusive, handler, bstream.GateOptionWithLogger(zlog))
-	forkableHandler := forkable.New(gateHandler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(libRef))
+	// Bound the reversible buffer: this hub is long-lived (per-pod) and runs on real
+	// chain LIB, so a LIB stall would grow it unbounded -> OOM. Fail fast instead
+	// (clean restart) — see ultraOS-doc dfuse-deep-dive/17 (B1). Tune per pod memory.
+	forkableHandler := forkable.New(gateHandler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(libRef), forkable.WithMaxReversibleBlocks(10_000))
 
 	joiningSourceFactory := bstream.SourceFromRefFactory(func(blockRef bstream.BlockRef, handler bstream.Handler) bstream.Source {
 		if blockRef.ID() == "" {

--- a/eosws/recenttxhub.go
+++ b/eosws/recenttxhub.go
@@ -139,7 +139,10 @@ func (h *RecentTxHub) Launch(ctx context.Context) {
 		return nil
 	})
 
-	forkableHandler := forkable.New(handler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(libRef))
+	// Bound the reversible buffer: this hub is long-lived (per-pod) and runs on real
+	// chain LIB, so a LIB stall would grow it unbounded -> OOM. Fail fast instead
+	// (clean restart) — see ultraOS-doc dfuse-deep-dive/17 (B1). Tune per pod memory.
+	forkableHandler := forkable.New(handler, forkable.WithLogger(zlog), forkable.WithExclusiveLIB(libRef), forkable.WithMaxReversibleBlocks(10_000))
 
 	joiningSourceFactory := bstream.SourceFromRefFactory(func(blockRef bstream.BlockRef, sh bstream.Handler) bstream.Source {
 		if blockRef.ID() == "" {


### PR DESCRIPTION
Pre-deploy review of the B1 wiring found **3 long-lived (per-pod) eosws consumers** on real chain LIB left uncapped — distinct from the short-lived per-request subscriptions intentionally excluded:
- `eosws/headinfo.go:99` (head-info hub, app.go:303)
- `eosws/recenttxhub.go:142` (recent-tx ring hub, app.go:279)
- `eosws/completion/pipeline.go:67` (completion pipeline, app.go:592, `source.Run()`)

On a LIB stall these grow the ForkDB unbounded → OOM eosws (the same class B1 closes for the ingest injectors). Cap each at 10,000 via `forkable.WithMaxReversibleBlocks` (fail fast → clean restart). Opt-in/additive — no behavior change below the cap.

**Verification:** `go build ./eosws/...` clean; `go test ./eosws/...` green; `go vet` clean. The `-race` detector surfaces a **pre-existing** `dmetrics.(*Set).add` race via `bstream.NewBuffer`/`NewGauge` in `TestOnGetActionsTraces` — confirmed present on clean develop (4 races in 15 runs) **without** this change; not in this change's code path. Completes B1 coverage (no exposed long-lived forkable). See ultraOS-doc dfuse-deep-dive/17 (B1).